### PR TITLE
Remove explicit jvmTarget specification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,12 +157,4 @@ subprojects {
     }
 
     sourceCompatibility = 1.8
-
-    compileKotlin {
-        kotlinOptions.jvmTarget = "1.8"
-    }
-
-    compileTestKotlin {
-        kotlinOptions.jvmTarget = "1.8"
-    }
 }


### PR DESCRIPTION
Kotlin 1.5 now targets JVM 1.8 [by defaut](https://kotlinlang.org/docs/whatsnew15.html#new-default-jvm-target-1-8), so there's no need to specify it again explicitly.